### PR TITLE
Migrating to the new assembly task key notations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,12 @@ libraryDependencies  ++= Seq(
             "ch.unibas.cs.gravis" %% "scalismo-ui" % "0.10.+" 
 )
 
-jarName in assembly := "exectuable.jar"
+assemblyJarName in assembly := "exectuable.jar"
 
 mainClass in assembly := Some("com.example.ExampleApp")
 
 
-mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
+assemblyMergeStrategy in assembly <<= (assemblyMergeStrategy in assembly) { (old) =>
   {
     case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
     case PathList("META-INF", s) if s.endsWith(".SF") || s.endsWith(".DSA") || s.endsWith(".RSA") => MergeStrategy.discard


### PR DESCRIPTION
`jarName` and `mergeStrategy` keys in assembly task are deprecated. Replacing them with new keys. 

Please see [assembly task](https://github.com/sbt/sbt-assembly#assembly-task) for more information.