### PR TITLE
using scalismo-ui 0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += Opts.resolver.sonatypeSnapshots
 
 libraryDependencies  ++= Seq(
             "ch.unibas.cs.gravis" % "scalismo-native-all" % "4.0.+",
-            "ch.unibas.cs.gravis" %% "scalismo-ui" % "0.13-RC2"
+            "ch.unibas.cs.gravis" %% "scalismo-ui" % "0.13.0"
 )
 
 assemblyJarName in assembly := "executable.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,8 @@ resolvers += Opts.resolver.sonatypeSnapshots
 
 
 libraryDependencies  ++= Seq(
-            "ch.unibas.cs.gravis" %% "scalismo" % "0.16.+",
             "ch.unibas.cs.gravis" % "scalismo-native-all" % "4.0.+",
-            "ch.unibas.cs.gravis" %% "scalismo-ui" % "0.12.+"
+            "ch.unibas.cs.gravis" %% "scalismo-ui" % "0.13-RC2"
 )
 
 assemblyJarName in assembly := "executable.jar"


### PR DESCRIPTION
Ideally we should release the 0.13 version  of the ui and not depend on a RC. 

I however need this for setting up the IDE documentation.